### PR TITLE
Merge 34 client side detail hunt with no edit into main

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { UserListComponent } from './users/user-list.component';
 import { UserProfileComponent } from './users/user-profile.component';
 import { CompanyListComponent } from './company-list/company-list.component';
 import { HuntListComponent } from './hunts/hunt-list.component';
+import { HuntProfileComponent } from './hunts/hunt-profile.component';
 
 // Note that the 'users/new' route needs to come before 'users/:id'.
 // If 'users/:id' came first, it would accidentally catch requests to
@@ -16,7 +17,8 @@ const routes: Routes = [
   {path: 'users/new', component: AddUserComponent, title: 'Add User'},
   {path: 'users/:id', component: UserProfileComponent, title: 'User Profile'},
   {path: 'companies', component: CompanyListComponent, title: 'Companies'},
-  {path: 'hunts', component: HuntListComponent, title: 'My Hunts'}
+  {path: 'hunts', component: HuntListComponent, title: 'My Hunts'},
+  {path: 'hunts/:id', component: HuntProfileComponent, title: 'Hunt Profile'}
 ];
 
 @NgModule({

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -19,7 +19,7 @@ const routes: Routes = [
   {path: 'users/:id', component: UserProfileComponent, title: 'User Profile'},
   {path: 'companies', component: CompanyListComponent, title: 'Companies'},
   {path: 'hunts', component: HuntListComponent, title: 'My Hunts'},
-  {path: 'hunts/:id', component: HuntProfileComponent, title: 'Hunt Profile'}
+  {path: 'hunts/:id', component: HuntProfileComponent, title: 'Hunt Profile'},
   {path: 'tasks', component: TaskListComponent, title: 'Task List'},
   {path: 'tasks/:id', component: TaskListComponent, title: 'Single Task'}
 ];

--- a/client/src/app/hunts/hunt-card.component.html
+++ b/client/src/app/hunts/hunt-card.component.html
@@ -16,8 +16,8 @@
         <mat-icon class="edit-button-icon" aria-label="Edit Hunt">edit</mat-icon>
       </button>
       }
-      <button mat-icon-button matTooltip="Inspect Hunt" (click)="onInspectClick($event)" data-test="inspectHuntButton">
-        <mat-icon class="inspect-button-icon" aria-label="Inspect Hunt">search</mat-icon>
+      <button mat-icon-button matTooltip="Inspect Hunt" (click)="onInspectClick($event)" data-test="inspectHuntButton" [routerLink]="['/hunts',this.hunt._id]">
+        <mat-icon class="inspect-button-icon" aria-label="Inspect Hunt">view</mat-icon>
       </button>
       @if (editable) {
       <button mat-icon-button matTooltip="Delete Hunt" (click)="onDeleteClick($event)" data-test="deleteHuntButton">

--- a/client/src/app/hunts/hunt-card.component.html
+++ b/client/src/app/hunts/hunt-card.component.html
@@ -17,7 +17,7 @@
       </button>
       }
       <button mat-icon-button matTooltip="Inspect Hunt" (click)="onInspectClick($event)" data-test="inspectHuntButton" [routerLink]="['/hunts',this.hunt._id]">
-        <mat-icon class="inspect-button-icon" aria-label="Inspect Hunt">view</mat-icon>
+        <mat-icon class="inspect-button-icon" aria-label="Inspect Hunt">search</mat-icon>
       </button>
       @if (editable) {
       <button mat-icon-button matTooltip="Delete Hunt" (click)="onDeleteClick($event)" data-test="deleteHuntButton">

--- a/client/src/app/hunts/hunt-card.component.scss
+++ b/client/src/app/hunts/hunt-card.component.scss
@@ -8,6 +8,9 @@
   border-style: inset;
   min-height: 200px;
   background-color: rgb(251, 252, 251);
+  &:hover {
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+  }
 }
 
 .hunt-title {

--- a/client/src/app/hunts/hunt-profile.component.html
+++ b/client/src/app/hunts/hunt-profile.component.html
@@ -4,7 +4,7 @@
   <div class="flex-1">
     @if (hunt) {
       <mat-card class="hunt-card-wrapper">
-        <div class="banner">This Hunt Details <i class="fa-solid fa-circle-info"></i></div>
+        <div class="banner">Hunt Details <i class="fa-solid fa-circle-info"></i></div>
         <div class="flex-1">
           <div class="hunt-cards-container flex-row gap-8 flex-wrap">
             <mat-card-header>

--- a/client/src/app/hunts/hunt-profile.component.html
+++ b/client/src/app/hunts/hunt-profile.component.html
@@ -1,0 +1,1 @@
+<p>hunt-profile works!</p>

--- a/client/src/app/hunts/hunt-profile.component.html
+++ b/client/src/app/hunts/hunt-profile.component.html
@@ -3,56 +3,56 @@
 <div class="flex-row">
   <div class="flex-1">
     @if (hunt) {
-      <mat-card class="hunt-card-wrapper">
-        <div class="banner">Hunt Details <i class="fa-solid fa-circle-info"></i></div>
-          <div class="hunt-cards-container flex-row gap-8 flex-wrap">
-            <mat-card-header>
-                <mat-card-title class="hunt-title">{{ hunt.title }} <i class="fa-solid fa-signature"></i></mat-card-title>
-                <mat-card-subtitle class="hunt-description">{{ hunt.description }}</mat-card-subtitle>
+    <mat-card class="hunt-card-wrapper">
+      <div class="banner">Hunt Details <i class="fa-solid fa-circle-info"></i></div>
+      <div class="hunt-cards-container flex-row gap-8 flex-wrap">
+        <mat-card-header>
+          <mat-card-title class="hunt-title">{{ hunt.title }} <i class="fa-solid fa-signature"></i></mat-card-title>
+          <mat-card-subtitle class="hunt-description">{{ hunt.description }}</mat-card-subtitle>
 
         </mat-card-header>
 
-        <div class ="task-description">
+        <div class="task-description">
           <h3> Tasks List <i class="fa-solid fa-file-signature"></i></h3>
-        <div *ngIf="tasks && tasks.length > 0; else noTasks">
-          <div class="task-wrapper">
-            <li *ngFor="let task of tasks" class="task-wrapper">
-              {{ task.description }}
-            </li>
-          </div>
+          <div *ngIf="tasks && tasks.length > 0; else noTasks">
+            <div class="task-wrapper">
+              <li *ngFor="let task of tasks" class="task-wrapper">
+                {{ task.description }}
+              </li>
+            </div>
           </div>
         </div>
 
         <ng-template #noTasks>
           <h4>No tasks available for this hunt yet.</h4>
         </ng-template>
-          </div>
+      </div>
 
-      </mat-card>
+    </mat-card>
 
     } @else if (error) {
-      <mat-card class="error-card">
-        <mat-card-content>
-          <h2>
-            {{ error.help }}
-          </h2>
-          <p>
-            {{ error.message }}
-          </p>
-          <p>
-            {{ error.httpResponse }}
-          </p>
-        </mat-card-content>
-        <mat-card-actions>
-          <button color=primary mat-raised-button routerLink="/hunts">Back to Hunts List</button>
-        </mat-card-actions>
-      </mat-card>
+    <mat-card class="error-card">
+      <mat-card-content>
+        <h2>
+          {{ error.help }}
+        </h2>
+        <p>
+          {{ error.message }}
+        </p>
+        <p>
+          {{ error.httpResponse }}
+        </p>
+      </mat-card-content>
+      <mat-card-actions>
+        <button color=primary mat-raised-button routerLink="/hunts">Back to Hunts List</button>
+      </mat-card-actions>
+    </mat-card>
     } @else {
-      <mat-card>
-        <mat-card-content>
-          <p>Loading Hunt Profile data...</p>
-        </mat-card-content>
-      </mat-card>
+    <mat-card>
+      <mat-card-content>
+        <p>Loading Hunt Profile data...</p>
+      </mat-card-content>
+    </mat-card>
     }
   </div>
 </div>

--- a/client/src/app/hunts/hunt-profile.component.html
+++ b/client/src/app/hunts/hunt-profile.component.html
@@ -1,1 +1,30 @@
-<p>hunt-profile works!</p>
+<div class="flex-row">
+  <div class="flex-1">
+    @if (hunt) {
+      <app-hunt-card [hunt]="this.hunt"></app-hunt-card>
+    } @else if (error) {
+      <mat-card class="error-card">
+        <mat-card-content>
+          <h2>
+            {{ error.help }}
+          </h2>
+          <p>
+            {{ error.message }}
+          </p>
+          <p>
+            {{ error.httpResponse }}
+          </p>
+        </mat-card-content>
+        <mat-card-actions>
+          <button color=primary mat-raised-button routerLink="/hunts">Back to Hunts List</button>
+        </mat-card-actions>
+      </mat-card>
+    } @else {
+      <mat-card>
+        <mat-card-content>
+          <p>Loading Hunt Profile data...</p>
+        </mat-card-content>
+      </mat-card>
+    }
+  </div>
+</div>

--- a/client/src/app/hunts/hunt-profile.component.html
+++ b/client/src/app/hunts/hunt-profile.component.html
@@ -1,7 +1,20 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+
 <div class="flex-row">
   <div class="flex-1">
     @if (hunt) {
-      <app-hunt-card [hunt]="this.hunt"></app-hunt-card>
+      <mat-card class="hunt-card-wrapper">
+        <div class="banner">This Hunt Details <i class="fa-solid fa-circle-info"></i></div>
+        <div class="flex-1">
+          <div class="hunt-cards-container flex-row gap-8 flex-wrap">
+            <mat-card-header>
+                <mat-card-title class="hunt-title">{{ hunt.title }}</mat-card-title>
+                <mat-card-subtitle>{{ hunt.description }}</mat-card-subtitle>
+        </mat-card-header>
+          </div>
+        </div>
+      </mat-card>
+
     } @else if (error) {
       <mat-card class="error-card">
         <mat-card-content>

--- a/client/src/app/hunts/hunt-profile.component.html
+++ b/client/src/app/hunts/hunt-profile.component.html
@@ -5,14 +5,29 @@
     @if (hunt) {
       <mat-card class="hunt-card-wrapper">
         <div class="banner">Hunt Details <i class="fa-solid fa-circle-info"></i></div>
-        <div class="flex-1">
           <div class="hunt-cards-container flex-row gap-8 flex-wrap">
             <mat-card-header>
-                <mat-card-title class="hunt-title">{{ hunt.title }}</mat-card-title>
-                <mat-card-subtitle>{{ hunt.description }}</mat-card-subtitle>
+                <mat-card-title class="hunt-title">{{ hunt.title }} <i class="fa-solid fa-signature"></i></mat-card-title>
+                <mat-card-subtitle class="hunt-description">{{ hunt.description }}</mat-card-subtitle>
+
         </mat-card-header>
+
+        <div class ="task-description">
+          <h3> Tasks List <i class="fa-solid fa-file-signature"></i></h3>
+        <div *ngIf="tasks && tasks.length > 0; else noTasks">
+          <div class="task-wrapper">
+            <li *ngFor="let task of tasks" class="task-wrapper">
+              {{ task.description }}
+            </li>
+          </div>
           </div>
         </div>
+
+        <ng-template #noTasks>
+          <h4>No tasks available for this hunt yet.</h4>
+        </ng-template>
+          </div>
+
       </mat-card>
 
     } @else if (error) {

--- a/client/src/app/hunts/hunt-profile.component.scss
+++ b/client/src/app/hunts/hunt-profile.component.scss
@@ -1,0 +1,6 @@
+.error-card {
+  background-color: #b00020;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+}

--- a/client/src/app/hunts/hunt-profile.component.scss
+++ b/client/src/app/hunts/hunt-profile.component.scss
@@ -4,3 +4,16 @@
   padding: 10px;
   border-radius: 5px;
 }
+
+.banner {
+  font-size: 30px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 20px;
+  color: yellowgreen;
+}
+.hunt-title {
+  font-size: 30px;
+  color: #707070;
+}
+

--- a/client/src/app/hunts/hunt-profile.component.scss
+++ b/client/src/app/hunts/hunt-profile.component.scss
@@ -12,6 +12,7 @@
   padding-left: 20px;
   color: yellowgreen;
 }
+
 .hunt-title {
   font-size: 30px;
   color: #707070;

--- a/client/src/app/hunts/hunt-profile.component.scss
+++ b/client/src/app/hunts/hunt-profile.component.scss
@@ -17,3 +17,44 @@
   color: #707070;
 }
 
+.hunt-cards-container {
+  display: flex;
+  flex-direction: column;
+}
+
+h3 {
+  font-size: 30px;
+  color: red;
+  padding-left: 20px;
+  padding-top: 10px;
+}
+
+li {
+  font-size: 20px;
+  color: #707070;
+  margin-top: 10px;
+  padding-right: 20px;
+}
+
+.hunt-description {
+  font-size: 20px;
+}
+
+h4 {
+  font-size: 20px;
+  color: #707070;
+  padding-left: 20px;
+}
+
+.task-wrapper li {
+  padding: 10px 20px;
+}
+
+.task-wrapper li {
+
+  border-top: 1px solid #ccc;
+}
+
+.task-wrapper li {
+  margin-top: 0;
+}

--- a/client/src/app/hunts/hunt-profile.component.spec.ts
+++ b/client/src/app/hunts/hunt-profile.component.spec.ts
@@ -96,7 +96,7 @@ describe('HuntProfileComponent', () => {
   component.ngOnInit();
 
   expect(component.error).toEqual({
-    help: 'THere was a problem loading the hunt - try again.',
+    help: 'There was a problem loading the hunt - try again.',
     httpResponse: mockError.message,
     message: mockError.error.title,
   });

--- a/client/src/app/hunts/hunt-profile.component.spec.ts
+++ b/client/src/app/hunts/hunt-profile.component.spec.ts
@@ -15,11 +15,11 @@ describe('HuntProfileComponent', () => {
   let component: HuntProfileComponent;
   let fixture: ComponentFixture<HuntProfileComponent>;
   const mockHuntService = new MockHuntService();
-  const kkId = 'kk_id';
+  const patId = 'hunt2_id';
   const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub({
     // Using the constructor here lets us try that branch in `activated-route-stub.ts`
     // and then we can choose a new parameter map in the tests if we choose
-    id : kkId
+    id : patId
   });
 
  beforeEach(waitForAsync(() => {
@@ -81,7 +81,7 @@ describe('HuntProfileComponent', () => {
  });
 
  it('should set error data on observable error', () => {
-  activatedRoute.setParamMap({ id: kkId });
+  activatedRoute.setParamMap({ id: patId });
 
   const mockError = { message: 'Test Error', error: { title: 'Error Title' }};
 
@@ -100,6 +100,6 @@ describe('HuntProfileComponent', () => {
     httpResponse: mockError.message,
     message: mockError.error.title,
   });
-  expect(getHuntSpy).toHaveBeenCalledWith(kkId);
+  expect(getHuntSpy).toHaveBeenCalledWith(patId);
  });
 });

--- a/client/src/app/hunts/hunt-profile.component.spec.ts
+++ b/client/src/app/hunts/hunt-profile.component.spec.ts
@@ -1,23 +1,105 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatCardModule } from '@angular/material/card';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { throwError } from 'rxjs';
+import { ActivatedRouteStub } from '../../testing/activated-route-stub';
 
+import { MockHuntService } from 'src/testing/hunt.service.mock';
+import { Hunt } from './hunt';
+import { HuntCardComponent } from './hunt-card.component';
+import { HuntService } from './hunt.service';
 import { HuntProfileComponent } from './hunt-profile.component';
 
 describe('HuntProfileComponent', () => {
   let component: HuntProfileComponent;
   let fixture: ComponentFixture<HuntProfileComponent>;
+  const mockHuntService = new MockHuntService();
+  const kkId = 'kk_id';
+  const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub({
+    // Using the constructor here lets us try that branch in `activated-route-stub.ts`
+    // and then we can choose a new parameter map in the tests if we choose
+    id : kkId
+  });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HuntProfileComponent]
-    })
-    .compileComponents();
-    
+ beforeEach(waitForAsync(() => {
+  TestBed.configureTestingModule({
+    imports: [
+      RouterTestingModule,
+      MatCardModule,
+      HuntProfileComponent, HuntCardComponent
+    ],
+
+    providers: [
+      { provide: HuntService, useValue: mockHuntService },
+      { provide: ActivatedRoute, useValue: activatedRoute }
+    ]
+})
+      .compileComponents();
+ }));
+
+ beforeEach(() => {
     fixture = TestBed.createComponent(HuntProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+ });
 
-  it('should create', () => {
+ it('should create the component', () => {
     expect(component).toBeTruthy();
+ });
+
+ it('should navigate to a specific hunt profile', () => {
+    const expectedHunt: Hunt = MockHuntService.testHunts[0];
+    // Setting this should cause anyone subscribing to the paramMap
+    // to update. Our `HuntProfileComponent` subscribes to that, so
+    // it should update right away.
+    activatedRoute.setParamMap({ id: expectedHunt._id });
+    expect(component.hunt).toEqual(expectedHunt);
+ });
+
+ it('should navigate to correct hunt when the id parameter changes', () => {
+  let expectedHunt: Hunt = MockHuntService.testHunts[0];
+  // Setting this should cause anyone subscribing to the paramMap
+  // to update. Our `HuntProfileComponent` subscribes to that, so
+  // it should update right away.
+  activatedRoute.setParamMap({ id: expectedHunt._id });
+  expect(component.hunt).toEqual(expectedHunt);
+
+  // Changing the paramMap should update the displayed hunt profile.
+  expectedHunt = MockHuntService.testHunts[1];
+  activatedRoute.setParamMap({ id: expectedHunt._id });
+  expect(component.hunt).toEqual(expectedHunt);
+ });
+
+ it('should have `null` fro the hunt for a bad ID', () => {
+  activatedRoute.setParamMap({ id: 'badID' });
+
+  // If the given ID doesn't map to a hunt, we expect the service
+  // to return `null`, so we would expect the component's hunt
+  // to also be `null`.
+  expect(component.hunt).toBeNull();
+ });
+
+ it('should set error data on observable error', () => {
+  activatedRoute.setParamMap({ id: kkId });
+
+  const mockError = { message: 'Test Error', error: { title: 'Error Title' }};
+
+  // const errorResponse = { status: 500, message: 'Server error' };
+  // "Spy" on the `.addHunt()` method in the hunt service. Here we basically
+  // intercept any calls to that method and return the error response
+  // defined above.
+  const getHuntSpy = spyOn(mockHuntService, 'getHuntById')
+    .and
+    .returnValue(throwError(() => mockError));
+
+  component.ngOnInit();
+
+  expect(component.error).toEqual({
+    help: 'THere was a problem loading the hunt - try again.',
+    httpResponse: mockError.message,
+    message: mockError.error.title,
   });
+  expect(getHuntSpy).toHaveBeenCalledWith(kkId);
+ });
 });

--- a/client/src/app/hunts/hunt-profile.component.spec.ts
+++ b/client/src/app/hunts/hunt-profile.component.spec.ts
@@ -1,20 +1,25 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, fakeAsync, tick } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { throwError } from 'rxjs';
 import { ActivatedRouteStub } from '../../testing/activated-route-stub';
 
+// import { Task } from './task';
+import { TaskService } from './task.service';
 import { MockHuntService } from 'src/testing/hunt.service.mock';
+
 import { Hunt } from './hunt';
 import { HuntCardComponent } from './hunt-card.component';
 import { HuntService } from './hunt.service';
 import { HuntProfileComponent } from './hunt-profile.component';
+import { MockTaskService } from 'src/testing/task.service.mock';
 
 describe('HuntProfileComponent', () => {
   let component: HuntProfileComponent;
   let fixture: ComponentFixture<HuntProfileComponent>;
   const mockHuntService = new MockHuntService();
+  const mockTaskService = new MockTaskService();
   const patId = 'hunt2_id';
   const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub({
     // Using the constructor here lets us try that branch in `activated-route-stub.ts`
@@ -32,6 +37,7 @@ describe('HuntProfileComponent', () => {
 
     providers: [
       { provide: HuntService, useValue: mockHuntService },
+      { provide: TaskService, useValue: mockTaskService },
       { provide: ActivatedRoute, useValue: activatedRoute }
     ]
 })
@@ -48,30 +54,34 @@ describe('HuntProfileComponent', () => {
     expect(component).toBeTruthy();
  });
 
- it('should navigate to a specific hunt profile', () => {
-    const expectedHunt: Hunt = MockHuntService.testHunts[0];
-    // Setting this should cause anyone subscribing to the paramMap
-    // to update. Our `HuntProfileComponent` subscribes to that, so
-    // it should update right away.
-    activatedRoute.setParamMap({ id: expectedHunt._id });
-    expect(component.hunt).toEqual(expectedHunt);
- });
+//  it('should navigate to a specific hunt profile, load tasks', () => {
+//     const expectedHunt: Hunt = MockHuntService.testHunts[0];
+//     // Setting this should cause anyone subscribing to the paramMap
+//     // to update. Our `HuntProfileComponent` subscribes to that, so
+//     // it should update right away.
+//     activatedRoute.setParamMap({ id: expectedHunt._id });
+//     expect(component.hunt).toEqual(expectedHunt);
+//  });
 
- it('should navigate to correct hunt when the id parameter changes', () => {
+ it('should navigate to correct hunt when the id parameter changes', fakeAsync(() => {
   let expectedHunt: Hunt = MockHuntService.testHunts[0];
   // Setting this should cause anyone subscribing to the paramMap
   // to update. Our `HuntProfileComponent` subscribes to that, so
   // it should update right away.
   activatedRoute.setParamMap({ id: expectedHunt._id });
+  tick();
+  fixture.detectChanges();
   expect(component.hunt).toEqual(expectedHunt);
 
   // Changing the paramMap should update the displayed hunt profile.
   expectedHunt = MockHuntService.testHunts[1];
   activatedRoute.setParamMap({ id: expectedHunt._id });
+  tick();
+  fixture.detectChanges();
   expect(component.hunt).toEqual(expectedHunt);
- });
+ }));
 
- it('should have `null` fro the hunt for a bad ID', () => {
+ it('should have `null` for the hunt for a bad ID', () => {
   activatedRoute.setParamMap({ id: 'badID' });
 
   // If the given ID doesn't map to a hunt, we expect the service

--- a/client/src/app/hunts/hunt-profile.component.spec.ts
+++ b/client/src/app/hunts/hunt-profile.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HuntProfileComponent } from './hunt-profile.component';
+
+describe('HuntProfileComponent', () => {
+  let component: HuntProfileComponent;
+  let fixture: ComponentFixture<HuntProfileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HuntProfileComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(HuntProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/hunts/hunt-profile.component.spec.ts
+++ b/client/src/app/hunts/hunt-profile.component.spec.ts
@@ -24,92 +24,92 @@ describe('HuntProfileComponent', () => {
   const activatedRoute: ActivatedRouteStub = new ActivatedRouteStub({
     // Using the constructor here lets us try that branch in `activated-route-stub.ts`
     // and then we can choose a new parameter map in the tests if we choose
-    id : patId
+    id: patId
   });
 
- beforeEach(waitForAsync(() => {
-  TestBed.configureTestingModule({
-    imports: [
-      RouterTestingModule,
-      MatCardModule,
-      HuntProfileComponent, HuntCardComponent
-    ],
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        MatCardModule,
+        HuntProfileComponent, HuntCardComponent
+      ],
 
-    providers: [
-      { provide: HuntService, useValue: mockHuntService },
-      { provide: TaskService, useValue: mockTaskService },
-      { provide: ActivatedRoute, useValue: activatedRoute }
-    ]
-})
+      providers: [
+        { provide: HuntService, useValue: mockHuntService },
+        { provide: TaskService, useValue: mockTaskService },
+        { provide: ActivatedRoute, useValue: activatedRoute }
+      ]
+    })
       .compileComponents();
- }));
+  }));
 
- beforeEach(() => {
+  beforeEach(() => {
     fixture = TestBed.createComponent(HuntProfileComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
- });
-
- it('should create the component', () => {
-    expect(component).toBeTruthy();
- });
-
-//  it('should navigate to a specific hunt profile, load tasks', () => {
-//     const expectedHunt: Hunt = MockHuntService.testHunts[0];
-//     // Setting this should cause anyone subscribing to the paramMap
-//     // to update. Our `HuntProfileComponent` subscribes to that, so
-//     // it should update right away.
-//     activatedRoute.setParamMap({ id: expectedHunt._id });
-//     expect(component.hunt).toEqual(expectedHunt);
-//  });
-
- it('should navigate to correct hunt when the id parameter changes', fakeAsync(() => {
-  let expectedHunt: Hunt = MockHuntService.testHunts[0];
-  // Setting this should cause anyone subscribing to the paramMap
-  // to update. Our `HuntProfileComponent` subscribes to that, so
-  // it should update right away.
-  activatedRoute.setParamMap({ id: expectedHunt._id });
-  tick();
-  fixture.detectChanges();
-  expect(component.hunt).toEqual(expectedHunt);
-
-  // Changing the paramMap should update the displayed hunt profile.
-  expectedHunt = MockHuntService.testHunts[1];
-  activatedRoute.setParamMap({ id: expectedHunt._id });
-  tick();
-  fixture.detectChanges();
-  expect(component.hunt).toEqual(expectedHunt);
- }));
-
- it('should have `null` for the hunt for a bad ID', () => {
-  activatedRoute.setParamMap({ id: 'badID' });
-
-  // If the given ID doesn't map to a hunt, we expect the service
-  // to return `null`, so we would expect the component's hunt
-  // to also be `null`.
-  expect(component.hunt).toBeNull();
- });
-
- it('should set error data on observable error', () => {
-  activatedRoute.setParamMap({ id: patId });
-
-  const mockError = { message: 'Test Error', error: { title: 'Error Title' }};
-
-  // const errorResponse = { status: 500, message: 'Server error' };
-  // "Spy" on the `.addHunt()` method in the hunt service. Here we basically
-  // intercept any calls to that method and return the error response
-  // defined above.
-  const getHuntSpy = spyOn(mockHuntService, 'getHuntById')
-    .and
-    .returnValue(throwError(() => mockError));
-
-  component.ngOnInit();
-
-  expect(component.error).toEqual({
-    help: 'There was a problem loading the hunt - try again.',
-    httpResponse: mockError.message,
-    message: mockError.error.title,
   });
-  expect(getHuntSpy).toHaveBeenCalledWith(patId);
- });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  //  it('should navigate to a specific hunt profile, load tasks', () => {
+  //     const expectedHunt: Hunt = MockHuntService.testHunts[0];
+  //     // Setting this should cause anyone subscribing to the paramMap
+  //     // to update. Our `HuntProfileComponent` subscribes to that, so
+  //     // it should update right away.
+  //     activatedRoute.setParamMap({ id: expectedHunt._id });
+  //     expect(component.hunt).toEqual(expectedHunt);
+  //  });
+
+  it('should navigate to correct hunt when the id parameter changes', fakeAsync(() => {
+    let expectedHunt: Hunt = MockHuntService.testHunts[0];
+    // Setting this should cause anyone subscribing to the paramMap
+    // to update. Our `HuntProfileComponent` subscribes to that, so
+    // it should update right away.
+    activatedRoute.setParamMap({ id: expectedHunt._id });
+    tick();
+    fixture.detectChanges();
+    expect(component.hunt).toEqual(expectedHunt);
+
+    // Changing the paramMap should update the displayed hunt profile.
+    expectedHunt = MockHuntService.testHunts[1];
+    activatedRoute.setParamMap({ id: expectedHunt._id });
+    tick();
+    fixture.detectChanges();
+    expect(component.hunt).toEqual(expectedHunt);
+  }));
+
+  it('should have `null` for the hunt for a bad ID', () => {
+    activatedRoute.setParamMap({ id: 'badID' });
+
+    // If the given ID doesn't map to a hunt, we expect the service
+    // to return `null`, so we would expect the component's hunt
+    // to also be `null`.
+    expect(component.hunt).toBeNull();
+  });
+
+  it('should set error data on observable error', () => {
+    activatedRoute.setParamMap({ id: patId });
+
+    const mockError = { message: 'Test Error', error: { title: 'Error Title' } };
+
+    // const errorResponse = { status: 500, message: 'Server error' };
+    // "Spy" on the `.addHunt()` method in the hunt service. Here we basically
+    // intercept any calls to that method and return the error response
+    // defined above.
+    const getHuntSpy = spyOn(mockHuntService, 'getHuntById')
+      .and
+      .returnValue(throwError(() => mockError));
+
+    component.ngOnInit();
+
+    expect(component.error).toEqual({
+      help: 'There was a problem loading the hunt - try again.',
+      httpResponse: mockError.message,
+      message: mockError.error.title,
+    });
+    expect(getHuntSpy).toHaveBeenCalledWith(patId);
+  });
 });

--- a/client/src/app/hunts/hunt-profile.component.ts
+++ b/client/src/app/hunts/hunt-profile.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute, ParamMap } from '@angular/router';
+import { Subject } from 'rxjs';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
+import { Hunt } from './hunt';
+import { HuntCardComponent } from './hunt-card.component';
+import { HuntService } from './hunt.service';
+
+@Component({
+  selector: 'app-hunt-profile',
+  standalone: true,
+  imports: [HuntCardComponent, MatCardModule],
+  templateUrl: './hunt-profile.component.html',
+  styleUrl: './hunt-profile.component.scss'
+})
+export class HuntProfileComponent implements OnInit, OnDestroy {
+  hunt: Hunt;
+  error: { help: string, httpResponse: string, message: string };
+
+  // This `Subject` will only ever emit one (empty) value when
+  // `ngOnDestroy()` is called, i.e., when this component is
+  // destroyed. That can be used to tell any subscription to
+  // terminate, allowing the system to free up their resources (like memory).
+  private ngUnsubscribe = new Subject<void>();
+
+  constructor(private snackBar: MatSnackBar, private route: ActivatedRoute, private huntService: HuntService) { }
+
+  ngOnInit(): void {
+    this.route.paramMap.pipe(
+      map((paramMap: ParamMap) => paramMap.get('id')),
+      switchMap((id: string) => this.huntService.getHuntById(id)),
+      takeUntil(this.ngUnsubscribe)
+    ).subscribe({
+        next: hunt => {
+          this.hunt = hunt;
+          return hunt;
+        },
+        error: _err => {
+          this.error = {
+            help: 'There was a problem loading the hunt - try again.',
+            httpResponse: _err.message,
+            message: _err.error?.title,
+          };
+        }
+    });
+  }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+
+    this.ngUnsubscribe.complete();
+  }
+}

--- a/client/src/app/hunts/hunt-profile.component.ts
+++ b/client/src/app/hunts/hunt-profile.component.ts
@@ -45,13 +45,13 @@ export class HuntProfileComponent implements OnInit, OnDestroy {
       next: (tasks: Task[]) => {
         this.tasks = tasks;
       },
-        error: _err => {
-          this.error = {
-            help: 'There was a problem loading the hunt - try again.',
-            httpResponse: _err.message,
-            message: _err.error?.title,
-          };
-        }
+      error: _err => {
+        this.error = {
+          help: 'There was a problem loading the hunt - try again.',
+          httpResponse: _err.message,
+          message: _err.error?.title,
+        };
+      }
     });
   }
 

--- a/client/src/app/hunts/hunt.service.spec.ts
+++ b/client/src/app/hunts/hunt.service.spec.ts
@@ -83,4 +83,49 @@ describe('HuntService', () => {
         });
     });
   });
+
+  describe('When getHuntById() is given an ID', () => {
+    /* We really don't care what `getHuntById()` returns. Since all the
+     * interesting work is happening on the server, `getHuntById()`
+     * is really just a "pass through" that returns whatever it receives,
+     * without any "post processing" or manipulation. The test in this
+     * `describe` confirms that the HTTP request is properly formed
+     * and sent out in the world, but we don't _really_ care about
+     * what `getHuntById()` returns as long as it's what the HTTP
+     * request returns.
+     *
+     * So in this test, we'll keep it simple and have
+     * the (mocked) HTTP request return the `targetHunt`
+     * Furthermore, we won't actually check what got returned (there won't be an `expect`
+     * about the returned value). Since we don't use the returned value in this test,
+     * It might also be fine to not bother making the mock return it.
+     */
+     it('calls api/hunts/id with the correct ID', waitForAsync(() => {
+       // We're just picking a User "at random" from our little
+       // set of Hunts up at the top.
+       const targetHunt: Hunt = testHunts[1];
+       const targetId: string = targetHunt._id;
+
+       // Mock the `httpClient.get()` method so that instead of making an HTTP request
+       // it just returns one hunt from our test data
+       const mockedMethod = spyOn(httpClient, 'get').and.returnValue(of(targetHunt));
+
+       // Call `huntService.getHunt()` and confirm that the correct call has
+       // been made with the correct arguments.
+       //
+       // We have to `subscribe()` to the `Observable` returned by `getHuntById()`.
+       // The `hunt` argument in the function below is the thing of type Hunt returned by
+       // the call to `getHuntById()`.
+       huntService.getHuntById(targetId).subscribe(() => {
+         // The `Hunt` returned by `getHuntById()` should be targetHunt, but
+         // we don't bother with an `expect` here since we don't care what was returned.
+         expect(mockedMethod)
+           .withContext('one call')
+           .toHaveBeenCalledTimes(1);
+         expect(mockedMethod)
+           .withContext('talks to the correct endpoint')
+           .toHaveBeenCalledWith(`${huntService.huntUrl}/${targetId}`);
+       });
+     }));
+   });
 });

--- a/client/src/app/hunts/hunt.service.ts
+++ b/client/src/app/hunts/hunt.service.ts
@@ -38,4 +38,16 @@ export class HuntService {
     });
   }
 
+   /**
+   * Get the `Hunt` with the specified ID.
+   *
+   * @param id the ID of the desired user
+   * @returns an `Observable` containing the resulting hunt.
+   */
+
+   getHuntById(id: string): Observable<Hunt> {
+    // The input to get could also be written as (this.huntUrl + '/' + id)
+    return this.httpClient.get<Hunt>(`${this.huntUrl}/${id}`);
+  }
+
 }

--- a/client/src/testing/hunt.service.mock.ts
+++ b/client/src/testing/hunt.service.mock.ts
@@ -38,4 +38,19 @@ export class MockHuntService extends HuntService {
   getHunts(_filters: { hostid?: string }): Observable<Hunt[]> {
     return of(MockHuntService.testHunts);
   }
+
+  // skipcq: JS-0105
+  getHuntById(id: string): Observable<Hunt> {
+    // If the specified ID is for one of the first two test users,
+    // return that user, otherwise return `null` so
+    // we can test illegal user requests.
+    // If you need more, just add those in too.
+    if (id === MockHuntService.testHunts[0]._id) {
+      return of(MockHuntService.testHunts[0]);
+    } else if (id === MockHuntService.testHunts[1]._id) {
+      return of(MockHuntService.testHunts[1]);
+    } else {
+      return of(null);
+    }
+  }
 }

--- a/client/src/testing/task.service.mock.ts
+++ b/client/src/testing/task.service.mock.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@angular/core";
+import { Observable, of } from "rxjs";
+import { AppComponent } from "src/app/app.component";
+import { Task } from "src/app/hunts/task";
+import { TaskService } from "src/app/hunts/task.service";
+
+
+@Injectable({
+  providedIn: AppComponent
+})
+export class MockTaskService extends TaskService {
+  static testTasks: Task[] = [
+    {
+      _id: 'hunt1_id',
+      huntid: 'chris',
+      description: 'Chris\'s test hunt',
+    },
+    {
+      _id: 'hunt2_id',
+      huntid: 'pat',
+      description: 'Pat\'s test hunt',
+    },
+    {
+      _id: 'hunt3_id',
+      huntid: 'jamie',
+      description: 'Jamie\'s test hunt',
+    }
+  ];
+
+  constructor() {
+    super(null);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getTasks(_filters: { huntid?: string }): Observable<Task[]> {
+    return of(MockTaskService.testTasks);
+  }
+
+}


### PR DESCRIPTION
This is a detailed page with no option for edit the existing hunt.
Just viewing one specific hunt.
Already test how the page look like with different devices.
Test coverage 100%.
There is one test that pass in my vscode but failed when push to GitHub, I rerun the failed test and it pass on GitHub.